### PR TITLE
Add image uploading for contact managers

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,13 +16,15 @@
         "express": "^4.21.1",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.10",
-        "mongoose": "^8.8.1"
+        "mongoose": "^8.8.1",
+        "multer": "^1.4.5-lts.1"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/mongoose": "^5.11.96",
+        "@types/multer": "^1.4.12",
         "@types/node": "^22.9.0",
         "typescript": "^5.6.3"
       }
@@ -124,6 +126,16 @@
         "mongoose": "*"
       }
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
@@ -199,6 +211,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -250,6 +268,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -276,6 +311,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -312,6 +362,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -653,6 +709,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -819,6 +881,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mongodb": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
@@ -953,6 +1036,24 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1008,6 +1109,12 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
       "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -1070,6 +1177,27 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1228,6 +1356,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1262,6 +1413,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -1291,6 +1448,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -1330,6 +1493,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,28 +1,33 @@
 {
-  "name":"backend",
-  "version":"1.0.0",
-  "main":"server.js",
-  "scripts": 
-    {"test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npx ts-node src/server.ts"},
-    "author":"",
-    "license":"ISC",
-    "dependencies":{
-      "bcryptjs":"^2.4.3",
-      "body-parser":"^1.20.3",
-      "cors":"^2.8.5",
-      "dotenv":"^16.4.5",
-      "express":"^4.21.1",
-      "jsonwebtoken":"^9.0.2",
-      "mongodb":"^6.10",
-      "mongoose":"^8.8.1"},
-      "devDependencies":{"@types/bcryptjs":"^2.4.6",
-        "@types/express":"^5.0.0",
-        "@types/jsonwebtoken":"^9.0.7",
-        "@types/mongoose":"^5.11.96",
-        "@types/node":"^22.9.0",
-        "typescript":"^5.6.3"
-      },
-      "keywords":[],
-      "description":""
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npx ts-node src/server.ts"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "body-parser": "^1.20.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.1",
+    "jsonwebtoken": "^9.0.2",
+    "mongodb": "^6.10",
+    "mongoose": "^8.8.1",
+    "multer": "^1.4.5-lts.1"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/express": "^5.0.0",
+    "@types/jsonwebtoken": "^9.0.7",
+    "@types/mongoose": "^5.11.96",
+    "@types/multer": "^1.4.12",
+    "@types/node": "^22.9.0",
+    "typescript": "^5.6.3"
+  },
+  "keywords": [],
+  "description": ""
 }

--- a/backend/src/controllers/managerController.ts
+++ b/backend/src/controllers/managerController.ts
@@ -26,6 +26,7 @@ export const create = async(req: Request, res: Response) => {
             author
         });
 
+        // Handle image upload
         if (req.file) {
             contactManager.image = req.file.filename;
         }

--- a/backend/src/controllers/managerController.ts
+++ b/backend/src/controllers/managerController.ts
@@ -12,20 +12,23 @@ interface IdHolder {
 
 export const create = async(req: Request, res: Response) => {
     try {
-        const { name, image, url } = req.body;
+        const { name, url } = req.body;
         const author = req.user_id;
-
-        if(!name || !image || !url || !author) {
+				
+        if(!name || !url || !author) {
             res.status(400).json({error: "Missing required fields"});
             return;
         }
 
         const contactManager = new ContactManager({
             name,
-            image,
             url,
             author
         });
+
+        if (req.file) {
+            contactManager.image = req.file.filename;
+        }
 
         await contactManager.save();
         res.sendStatus(201);

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -1,0 +1,31 @@
+import multer from 'multer';
+
+const maxFileSize = 1024 * 1024 * 8; // 8MB
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, 'uploads/');
+  },
+  filename: (req, file, cb) => {
+    const filename = `${Date.now()}-${file.originalname}`;
+    cb(null, filename);
+  },
+});
+
+const fileFilter = (req, file, cb) => {
+    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
+    if (!allowedTypes.includes(file.mimetype)) {
+      const error = new Error('Incorrect file type');
+      return cb(error);
+    } 
+    
+    return cb(null, true);
+}
+
+const upload = multer({
+    storage: storage,
+    fileFilter: fileFilter,
+    limits: {
+      fileSize: maxFileSize,
+    },
+});

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -1,5 +1,7 @@
-import multer from 'multer';
+import multer, { FileFilterCallback } from 'multer';
+import { Request } from 'express';
 
+type File = Express.Multer.File;
 const maxFileSize = 1024 * 1024 * 8; // 8MB
 
 const storage = multer.diskStorage({
@@ -12,7 +14,7 @@ const storage = multer.diskStorage({
   },
 });
 
-const fileFilter = (req, file, cb) => {
+const fileFilter = (req: Request, file: File, cb: FileFilterCallback) => {
     const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
     if (!allowedTypes.includes(file.mimetype)) {
       const error = new Error('Incorrect file type');
@@ -29,3 +31,5 @@ const upload = multer({
       fileSize: maxFileSize,
     },
 });
+
+export default upload;

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -1,6 +1,7 @@
 import multer, { FileFilterCallback } from 'multer';
 import { Request } from 'express';
 import fs from 'fs';
+import path from 'path';
 
 type File = Express.Multer.File;
 const maxFileSize = 1024 * 1024 * 8; // 8MB
@@ -17,7 +18,8 @@ const storage = multer.diskStorage({
   filename: (req, file, cb) => {
     // Generate a unique name for the file
     // Use the field name and current timestamp as the file name
-    const filename = `${file.fieldname}-${Date.now()}`;
+    const ext = path.extname(file.originalname);
+    const filename = `${file.fieldname}-${Date.now()}${ext}`;
 
     cb(null, filename);
   },

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 type File = Express.Multer.File;
 const maxFileSize = 1024 * 1024 * 8; // 8MB
 const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
-const uploadFolder = 'uploads';
+const uploadFolder = process.env.UPLOAD_FOLDER || 'uploads';
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -1,21 +1,29 @@
 import multer, { FileFilterCallback } from 'multer';
 import { Request } from 'express';
+import fs from 'fs';
 
 type File = Express.Multer.File;
 const maxFileSize = 1024 * 1024 * 8; // 8MB
+const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
+const uploadFolder = 'uploads';
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-    cb(null, 'uploads/');
+    // Create the uploads folder if it doesn't exist
+    fs.mkdirSync(uploadFolder, { recursive: true });
+
+    cb(null, uploadFolder);
   },
   filename: (req, file, cb) => {
-    const filename = `${Date.now()}-${file.originalname}`;
+    // Generate a unique name for the file
+    // Use the field name and current timestamp as the file name
+    const filename = `${file.fieldname}-${Date.now()}`;
+
     cb(null, filename);
   },
 });
 
 const fileFilter = (req: Request, file: File, cb: FileFilterCallback) => {
-    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
     if (!allowedTypes.includes(file.mimetype)) {
       const error = new Error('Incorrect file type');
       return cb(error);

--- a/backend/src/models/ContactManager.ts
+++ b/backend/src/models/ContactManager.ts
@@ -8,7 +8,8 @@ const contactManagerSchema = new mongoose.Schema(
         },
         image: {
             type: String,
-            required: true,
+            default: null,
+            required: false,
         },
         url: {
             type: String,

--- a/backend/src/routes/managerRoute.ts
+++ b/backend/src/routes/managerRoute.ts
@@ -1,11 +1,11 @@
 import express from 'express';
 import * as ManagerController from '../controllers/managerController';
 import { authenticateToken } from '../middleware/tokens';
-
+import upload from '../middleware/upload';
 
 const router = express.Router();
 
-router.post('/', authenticateToken, ManagerController.create);
+router.post('/', authenticateToken, upload.single('image'), ManagerController.create);
 router.get('/', ManagerController.getAll);
 router.get('/:id', ManagerController.get);
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -27,7 +27,6 @@ app.use(bodyParser.json());
 // In production, Nginx will serve the static files. 
 if(env === 'development') {
     const upload_dir = process.env.UPLOAD_FOLDER || 'uploads';
-    console
     app.use('/uploads', express.static(upload_dir));
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,6 +24,9 @@ mongoose.connect(process.env.MONGODB_URI!, {
 
 app.use(bodyParser.json());
 
+// Serve uploads folder statically.
+app.use('/uploads', express.static('uploads'));
+
 app.use('/api/auth', AuthRoute);
 app.use('/api/contact-managers', ManagerRoute);
 app.use('/api/reviews', ReviewRoute);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -28,9 +28,9 @@ app.use(bodyParser.json());
 // Serve uploads folder statically.
 app.use('/uploads', express.static(upload_dir));
 
-app.use('/api/auth', AuthRoute);
-app.use('/api/contact-managers', ManagerRoute);
-app.use('/api/reviews', ReviewRoute);
+app.use('/auth', AuthRoute);
+app.use('/contact-managers', ManagerRoute);
+app.use('/reviews', ReviewRoute);
 
 app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -31,9 +31,9 @@ if(env === 'development') {
     app.use('/uploads', express.static(upload_dir));
 }
 
-app.use('/auth', AuthRoute);
-app.use('/contact-managers', ManagerRoute);
-app.use('/reviews', ReviewRoute);
+app.use('/api/auth', AuthRoute);
+app.use('/api/contact-managers', ManagerRoute);
+app.use('/api/reviews', ReviewRoute);
 
 app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,7 +1,7 @@
+import 'dotenv/config';
 import express from 'express';
 import bodyParser from 'body-parser';
 import mongoose from 'mongoose';
-import dotenv from 'dotenv';
 
 import AuthRoute from './routes/authRoute';
 import ManagerRoute from './routes/managerRoute';
@@ -12,9 +12,7 @@ import { Request, Response } from 'express';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
-const upload_dir = process.env.UPLOAD_DIR || 'uploads';
-
-dotenv.config();
+const env = process.env.NODE_ENV || 'development';
 
 mongoose.connect(process.env.MONGODB_URI!, {
 }).then(() => {
@@ -25,8 +23,13 @@ mongoose.connect(process.env.MONGODB_URI!, {
 
 app.use(bodyParser.json());
 
-// Serve uploads folder statically.
-app.use('/uploads', express.static(upload_dir));
+// Serve static files in development.
+// In production, Nginx will serve the static files. 
+if(env === 'development') {
+    const upload_dir = process.env.UPLOAD_FOLDER || 'uploads';
+    console
+    app.use('/uploads', express.static(upload_dir));
+}
 
 app.use('/auth', AuthRoute);
 app.use('/contact-managers', ManagerRoute);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,7 @@ import { Request, Response } from 'express';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
+const upload_dir = process.env.UPLOAD_DIR || 'uploads';
 
 dotenv.config();
 
@@ -25,7 +26,7 @@ mongoose.connect(process.env.MONGODB_URI!, {
 app.use(bodyParser.json());
 
 // Serve uploads folder statically.
-app.use('/uploads', express.static('uploads'));
+app.use('/uploads', express.static(upload_dir));
 
 app.use('/api/auth', AuthRoute);
 app.use('/api/contact-managers', ManagerRoute);


### PR DESCRIPTION
Add support for (optionally) uploading images on the `POST /api/contact-managers` route.

Each `ContactManager` object has a filename in the `image` property associated with it that will be accessible at `/uploads`. If an image was not provided, `image` will be `null`. In production, we will serve our uploads folder with nginx. If `NODE_ENV` is `development` (the default) Express will serve it. 

The actual folder path can be set by changing `UPLOAD_FOLDER` in the .env file (by default, it is just `uploads/` in the backend folder).