### PR TITLE
Implement search across ContactManagers

### DIFF
--- a/backend/src/controllers/managerController.ts
+++ b/backend/src/controllers/managerController.ts
@@ -2,8 +2,9 @@ import { Request, Response } from 'express';
 import ContactManager from '../models/ContactManager';
 import mongoose from 'mongoose';
 
-interface StringBearer {
+interface ManagerQuery {
     page?: string;
+    search?: string;
 }
 
 interface IdHolder {
@@ -39,18 +40,18 @@ export const create = async(req: Request, res: Response) => {
 };
 
 
-export const getAll = async(req: Request<{}, {}, {}, StringBearer>, res: Response) => {
+export const getAll = async(req: Request<{}, {}, {}, ManagerQuery>, res: Response) => {
     try {
         const { query } = req;
-        const page = query.page;
+        const { page, search } = query;
 
         if(!page) {
             res.status(400).json({error: "Missing required fields"});
             return;
         }
 
-
-        var allManagers = await ContactManager.findAllManagersWithAvgRating();
+        // Search is optional, this will return all managers if not provided
+        var allManagers = await ContactManager.findAllManagersWithAvgRating(search);
 
         res.status(201).json(allManagers);
     } catch (error) {

--- a/backend/src/models/ContactManager.ts
+++ b/backend/src/models/ContactManager.ts
@@ -23,8 +23,14 @@ const contactManagerSchema = new mongoose.Schema(
     { 
         statics: {
             // Find contact manager w/ average rating
-            async findAllManagersWithAvgRating() {
+            async findAllManagersWithAvgRating(searchQuery?: string) {
                 const contactManagers = await this.aggregate([
+                    // Only include a search query object if a search query is provided
+                    ...(searchQuery ? [{
+                        $match: {
+                            name: { $regex: searchQuery, $options: "i" },
+                        },
+                    }]: []),
                     {
                         $lookup: {
                             from: "reviews",


### PR DESCRIPTION
Implement search in the `GET /api/contact-managers` route using an optional search parameter.

Searches only across names, could match more if we wanted to.